### PR TITLE
Fix PDF page-flip speed by ACKing SDK duration callbacks

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -57,6 +57,12 @@ impl Server {
             "/splash.jpg" => Response::from_data(SPLASH_JPG).boxed(),
             "/0.xlf.html" => Response::from_data(SPLASH_HTML).boxed(),
 
+            // SDK duration callbacks — just ACK them; arexibo uses XLF durations
+            "/duration/set" | "/duration/extend" | "/duration/expire" =>
+                Response::from_data(b"{}").with_header(
+                    Header::from_bytes(b"Content-Type", b"application/json").unwrap()
+                ).boxed(),
+
             // any other static files
             url => {
                 let parts = url.split('?').collect_vec();


### PR DESCRIPTION
## Summary

- ACK `/duration/set`, `/duration/extend`, and `/duration/expire` endpoints with `200 {}` in the embedded HTTP server
- Fixes PDF widgets flipping pages at near-instant speed (~11ms instead of configured duration)
- No processing of duration values needed — arexibo already uses XLF durations for region timing

Fixes #10

## Test plan

- [x] Build and run arexibo with a layout containing a PDF widget
- [x] Verify PDF pages flip at configured duration (e.g. 3s per page)
- [x] Verify no more 404 warnings in log for `/duration/set`
- [x] Verify other widgets (clock, global, images) still render correctly