### PR TITLE
Audit: sync RPM CI default-version to 0.3.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -1,0 +1,24 @@
+name: Build Arexibo DEB
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    uses: xibo-players/.github/.github/workflows/build-deb.yml@main
+    with:
+      package-name: arexibo
+      deb-script: 'deb/build-deb.sh'
+      distro-matrix: '["ubuntu:24.04", "debian:trixie"]'
+      arch-matrix: '["amd64", "arm64"]'
+      extra-build-deps: 'cargo cmake g++ libdbus-1-dev libzmq3-dev qt6-webengine-dev libudev-dev pkg-config'
+      gpg-sign: true
+      default-version: '0.3.3'
+      publish-to-repo: true
+      create-github-release: true
+    secrets: inherit

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -20,5 +20,4 @@ jobs:
       gpg-sign: true
       default-version: '0.3.3'
       publish-to-repo: true
-      create-github-release: true
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Create GitHub Release
 on:
   push:
     tags: ['v*']
+  workflow_dispatch:
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,4 @@ jobs:
     uses: xibo-players/.github/.github/workflows/create-release.yml@main
     with:
       package-name: arexibo
-      rpm-arch: 'x86_64+aarch64'
-      deb-arch: 'amd64+arm64'
       description: 'Minimal native Xibo digital signage player written in Rust.'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,14 @@
+name: Create GitHub Release
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  release:
+    uses: xibo-players/.github/.github/workflows/create-release.yml@main
+    with:
+      package-name: arexibo
+      rpm-arch: 'x86_64+aarch64'
+      deb-arch: 'amd64+arm64'
+      description: 'Minimal native Xibo digital signage player written in Rust.'

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -1,0 +1,23 @@
+name: Build Arexibo RPM
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    uses: xibo-players/.github/.github/workflows/build-rpm.yml@main
+    with:
+      package-name: arexibo
+      rpm-spec: 'rpm/arexibo.spec'
+      arch-matrix: '["x86_64", "aarch64"]'
+      source-tarball: 'full'
+      gpg-sign: true
+      default-version: '0.3.1'
+      publish-to-repo: true
+      create-github-release: true
+    secrets: inherit

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -14,6 +14,7 @@ jobs:
     with:
       package-name: arexibo
       rpm-spec: 'rpm/arexibo.spec'
+      fedora-matrix: '["43", "44"]'
       arch-matrix: '["x86_64", "aarch64"]'
       source-tarball: 'full'
       gpg-sign: true

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -20,5 +20,4 @@ jobs:
       gpg-sign: true
       default-version: '0.3.1'
       publish-to-repo: true
-      create-github-release: true
     secrets: inherit

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -14,7 +14,7 @@ jobs:
     with:
       package-name: arexibo
       rpm-spec: 'rpm/arexibo.spec'
-      fedora-matrix: '["43", "44"]'
+      fedora-matrix: '["43"]'
       arch-matrix: '["x86_64", "aarch64"]'
       source-tarball: 'full'
       gpg-sign: true

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -18,6 +18,6 @@ jobs:
       arch-matrix: '["x86_64", "aarch64"]'
       source-tarball: 'full'
       gpg-sign: true
-      default-version: '0.3.1'
+      default-version: '0.3.3'
       publish-to-repo: true
     secrets: inherit

--- a/deb/build-deb.sh
+++ b/deb/build-deb.sh
@@ -57,7 +57,7 @@ Description: Rust-based digital signage player for Xibo CMS
  Arexibo is a Rust-based digital signage player compatible with Xibo CMS.
  It provides a lightweight alternative to the official Xibo player,
  designed for kiosk and digital signage deployments on Linux.
-Homepage: https://github.com/linuxnow/arexibo
+Homepage: https://github.com/birkenfeld/arexibo
 EOF
 
 # Build DEB

--- a/deb/build-deb.sh
+++ b/deb/build-deb.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Build arexibo DEB package
+# Usage: ./deb/build-deb.sh <version> [release]
+set -euo pipefail
+
+VERSION="${1:?Usage: $0 <version> [release]}"
+
+# Parse version-release (e.g. 0.3.1-2 → version=0.3.1, release=2)
+# $2 from shared workflow overrides parsed release
+BASE_VERSION="${VERSION%%-*}"
+if [[ -n "${2:-}" ]]; then
+  RELEASE="$2"
+elif [[ "$VERSION" == *-* ]]; then
+  RELEASE="${VERSION#*-}"
+else
+  RELEASE="1"
+fi
+
+# Detect architecture
+ARCH=$(dpkg --print-architecture)
+
+echo "Building arexibo ${BASE_VERSION}-${RELEASE} for ${ARCH}"
+
+# Build Rust binary
+export CARGO_NET_GIT_FETCH_WITH_CLI=true
+cargo build --release
+
+# Create DEB package structure
+PKG_DIR="deb-pkg/arexibo"
+rm -rf deb-pkg
+mkdir -p "${PKG_DIR}/DEBIAN"
+mkdir -p "${PKG_DIR}/usr/bin"
+mkdir -p "${PKG_DIR}/usr/share/doc/arexibo"
+mkdir -p "${PKG_DIR}/usr/share/applications"
+mkdir -p "${PKG_DIR}/usr/share/icons/hicolor/256x256/apps"
+mkdir -p "${PKG_DIR}/usr/share/icons/hicolor/scalable/apps"
+
+# Install files
+install -m755 target/release/arexibo "${PKG_DIR}/usr/bin/arexibo"
+install -m644 LICENSE "${PKG_DIR}/usr/share/doc/arexibo/"
+install -m644 README.md "${PKG_DIR}/usr/share/doc/arexibo/"
+install -m644 CHANGELOG.md "${PKG_DIR}/usr/share/doc/arexibo/"
+install -m644 arexibo.desktop "${PKG_DIR}/usr/share/applications/"
+install -m644 assets/arexibo-256.png "${PKG_DIR}/usr/share/icons/hicolor/256x256/apps/arexibo.png"
+install -m644 assets/logo.svg "${PKG_DIR}/usr/share/icons/hicolor/scalable/apps/arexibo.svg"
+
+# Create control file
+cat > "${PKG_DIR}/DEBIAN/control" << EOF
+Package: arexibo
+Version: ${BASE_VERSION}-${RELEASE}
+Section: misc
+Priority: optional
+Architecture: ${ARCH}
+Depends: libqt6webenginecore6, libqt6webenginewidgets6, libdbus-1-3, libzmq5
+Maintainer: Pau Aliagas <pau@linuxnow.com>
+Description: Rust-based digital signage player for Xibo CMS
+ Arexibo is a Rust-based digital signage player compatible with Xibo CMS.
+ It provides a lightweight alternative to the official Xibo player,
+ designed for kiosk and digital signage deployments on Linux.
+Homepage: https://github.com/linuxnow/arexibo
+EOF
+
+# Build DEB
+mkdir -p dist
+dpkg-deb --build "${PKG_DIR}" "dist/arexibo_${BASE_VERSION}-${RELEASE}_${ARCH}.deb"
+
+echo "Built DEBs:"
+ls -lh dist/*.deb
+
+# Clean up
+rm -rf deb-pkg

--- a/rpm/arexibo.spec
+++ b/rpm/arexibo.spec
@@ -1,0 +1,63 @@
+%global debug_package %{nil}
+
+Name:           arexibo
+Version:        0.3.3
+Release:        1%{?dist}
+Summary:        Rust-based digital signage player for Xibo CMS
+
+License:        AGPLv3+
+URL:            https://github.com/xibo-players/arexibo
+Source0:        %{name}-%{version}.tar.gz
+
+BuildRequires:  rust >= 1.75
+BuildRequires:  cargo
+BuildRequires:  cmake
+BuildRequires:  gcc-c++
+BuildRequires:  dbus-devel >= 1.6
+BuildRequires:  zeromq-devel >= 4.1
+BuildRequires:  qt6-qtwebengine-devel
+
+Requires:       qt6-qtwebengine
+Requires:       dbus
+Requires:       zeromq
+
+%description
+Arexibo is a Rust-based digital signage player compatible with Xibo CMS.
+It provides a lightweight alternative to the official Xibo player,
+designed for kiosk and digital signage deployments on Linux.
+
+%prep
+%autosetup -n %{name}-%{version}
+
+%build
+export CARGO_NET_GIT_FETCH_WITH_CLI=true
+cargo build --release
+
+%install
+install -Dm755 target/release/arexibo %{buildroot}%{_bindir}/arexibo
+install -Dm644 arexibo.desktop %{buildroot}%{_datadir}/applications/arexibo.desktop
+install -Dm644 assets/arexibo-256.png %{buildroot}%{_datadir}/icons/hicolor/256x256/apps/arexibo.png
+install -Dm644 assets/logo.svg %{buildroot}%{_datadir}/icons/hicolor/scalable/apps/arexibo.svg
+
+%files
+%license LICENSE
+%doc README.md CHANGELOG.md
+%{_bindir}/arexibo
+%{_datadir}/applications/arexibo.desktop
+%{_datadir}/icons/hicolor/256x256/apps/arexibo.png
+%{_datadir}/icons/hicolor/scalable/apps/arexibo.svg
+
+%changelog
+* Wed Mar 12 2026 Pau Aliagas <pau@linuxnow.com> - 0.3.1-4
+- Install desktop entry and icon in RPM and DEB packages
+- Merge upstream dependency updates
+
+* Sun Mar 23 2026 Pau Aliagas <linuxnow@gmail.com> - 0.3.3-1
+- Sync with upstream v0.3.3
+
+* Fri Feb 28 2026 Pau Aliagas <pau@linuxnow.com> - 0.3.1-2
+- Install desktop entry and icon for proper desktop integration (closes #6)
+
+* Tue Feb 18 2026 Pau Aliagas <pau@linuxnow.com> - 0.3.1-1
+- Clean rebuild: PDF support, NotAuthorized exit code, dependency updates
+- Thin workflow callers for RPM, DEB and image builds

--- a/rpm/arexibo.spec
+++ b/rpm/arexibo.spec
@@ -2,7 +2,7 @@
 
 Name:           arexibo
 Version:        0.3.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Rust-based digital signage player for Xibo CMS
 
 License:        AGPLv3+
@@ -51,6 +51,9 @@ install -Dm644 assets/logo.svg %{buildroot}%{_datadir}/icons/hicolor/scalable/ap
 * Wed Mar 12 2026 Pau Aliagas <pau@linuxnow.com> - 0.3.1-4
 - Install desktop entry and icon in RPM and DEB packages
 - Merge upstream dependency updates
+
+* Sat Mar 29 2026 Pau Aliagas <linuxnow@gmail.com> - 0.3.3-2
+- Rebuild for Fedora 44
 
 * Sun Mar 23 2026 Pau Aliagas <linuxnow@gmail.com> - 0.3.3-1
 - Sync with upstream v0.3.3


### PR DESCRIPTION
## Summary
- rpm.yml: 0.3.1 -> 0.3.3 to match spec and deb.yml

## Test plan
- [ ] Run `workflow_dispatch` for RPM: verify version is 0.3.3