### PR TITLE
feat: add arexibo.service systemd user unit

### DIFF
--- a/arexibo.service
+++ b/arexibo.service
@@ -1,0 +1,29 @@
+# arexibo - Rust-based digital signage player for Xibo CMS
+# systemd user unit
+
+[Unit]
+Description=arexibo Digital Signage Player
+After=graphical-session.target
+Requisite=graphical-session.target
+StartLimitBurst=20
+StartLimitIntervalSec=300
+
+[Service]
+Type=simple
+EnvironmentFile=-%h/.local/share/xibo/env
+ExecStart=/usr/bin/arexibo --allow-offline %h/.local/share/xibo
+ExecStartPre=/bin/sh -c '[ -f %h/.local/share/xibo/cms.json ]'
+Restart=on-failure
+RestartSec=5s
+
+# Resource limits
+MemoryMax=1536M
+MemoryHigh=1G
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=arexibo
+
+[Install]
+WantedBy=graphical-session.target


### PR DESCRIPTION
Adds a systemd user service so arexibo can be managed with:

```bash
systemctl --user start arexibo.service
systemctl --user enable arexibo.service
```

Features:
- Requires `cms.json` before starting
- Restart on failure with 5s delay
- Memory limits (1.5 GB max)
- Journal logging

Closes #18