### PR TITLE
ci: add GitHub Actions workflows for build and release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -1,0 +1,23 @@
+name: Build Arexibo DEB
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    uses: xibo-players/.github/.github/workflows/build-deb.yml@main
+    with:
+      package-name: arexibo
+      deb-script: 'deb/build-deb.sh'
+      distro-matrix: '["ubuntu:24.04", "debian:trixie"]'
+      arch-matrix: '["amd64", "arm64"]'
+      extra-build-deps: 'cargo cmake g++ libdbus-1-dev libzmq3-dev qt6-webengine-dev libudev-dev pkg-config'
+      gpg-sign: true
+      default-version: '0.3.3'
+      publish-to-repo: true
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,13 @@
+name: Create GitHub Release
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+jobs:
+  release:
+    uses: xibo-players/.github/.github/workflows/create-release.yml@main
+    with:
+      package-name: arexibo
+      description: 'Minimal native Xibo digital signage player written in Rust.'

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -1,0 +1,23 @@
+name: Build Arexibo RPM
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    uses: xibo-players/.github/.github/workflows/build-rpm.yml@main
+    with:
+      package-name: arexibo
+      rpm-spec: 'rpm/arexibo.spec'
+      fedora-matrix: '["43"]'
+      arch-matrix: '["x86_64", "aarch64"]'
+      source-tarball: 'full'
+      gpg-sign: true
+      default-version: '0.3.3'
+      publish-to-repo: true
+    secrets: inherit


### PR DESCRIPTION
Adds CI/CD workflows:

- `rpm.yml` — RPM build (Fedora 43, x86_64 + aarch64)
- `deb.yml` — DEB build (Ubuntu 24.04, Debian Trixie)
- `release.yml` — GitHub Release creation on tag push
- `dependabot.yml` — weekly cargo + actions dependency updates