### PR TITLE
fix: prevent path traversal in local HTTP server

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -67,7 +67,18 @@ impl Server {
             url => {
                 let parts = url.split('?').collect_vec();
                 let path = dir.join(&parts[0][1..]);
-                let ext = path.extension().and_then(|e| e.to_str());
+
+                // Prevent path traversal — verify resolved path stays inside cache dir
+                let canonical_dir = dir.canonicalize().unwrap_or_else(|_| dir.clone());
+                let canonical_path = match path.canonicalize() {
+                    Ok(p) if p.starts_with(&canonical_dir) => p,
+                    _ => {
+                        log::warn!("processing HTTP req {}: 403 path outside cache dir", req.url());
+                        return Ok(Response::empty(403).boxed());
+                    }
+                };
+
+                let ext = canonical_path.extension().and_then(|e| e.to_str());
 
                 let query_params = parts.get(1).map(|par| par.split('&').map(|p| {
                     let mut kv = p.split('=');
@@ -76,11 +87,11 @@ impl Server {
                     (k, v)
                 }).collect::<HashMap<_, _>>()).unwrap_or_default();
 
-                if !path.is_file() {
+                if !canonical_path.is_file() {
                     log::warn!("processing HTTP req {}: 404 not found", req.url());
                     return Ok(Response::empty(404).boxed());
                 }
-                let mut fp = fs::File::open(&path)?;
+                let mut fp = fs::File::open(&canonical_path)?;
 
                 // implement replacing [[ViewPortWidth]] by requested width
                 if ext == Some("html") && query_params.contains_key("w") {


### PR DESCRIPTION
Closes #27.

Canonicalise the resolved path and verify it stays inside the cache directory before serving. Requests for paths outside the cache (e.g. \`/../../../etc/passwd\`) now return 403 instead of the file contents.

### Test

Before:

\`\`\`
\$ curl -s 'http://127.0.0.1:<port>/..%2F..%2F..%2F..%2Fetc%2Fpasswd'
root:x:0:0:root:/root:/bin/bash
...
\`\`\`

After:

\`\`\`
\$ curl -s -o /dev/null -w '%{http_code}\n' 'http://127.0.0.1:<port>/..%2F..%2F..%2F..%2Fetc%2Fpasswd'
403
\`\`\`

### Notes

Canonicalisation via \`Path::canonicalize()\` which resolves symlinks and \`..\` components. Falls back to the non-canonical cache-dir path on \`canonicalize()\` error for the dir itself (handles the case where the cache dir is a symlink that breaks during a restart — matches prior behaviour for that edge case). All actual path checks use the canonical form.

Validated in our fork's RPM + DEB packaging, no observed regressions in normal layout-fetch behaviour.