### PR TITLE
fix: 2 pre-existing clippy errors (to_string_in_format_args + needless_borrows_for_generic_args)

### DIFF
--- a/src/mainloop.rs
+++ b/src/mainloop.rs
@@ -324,7 +324,7 @@ impl Handler {
     fn schedule_check(&mut self) {
         let new_layouts = self.schedule.layouts_now();
         if new_layouts != self.layouts {
-            log::info!("new layouts in schedule: {}", new_layouts.iter().format(", ").to_string());
+            log::info!("new layouts in schedule: {}", new_layouts.iter().format(", "));
             self.to_gui.send(ToGui::Layouts(new_layouts.clone())).unwrap();
             self.layouts = new_layouts;
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -70,7 +70,7 @@ impl Server {
                 let path = dir.join(&parts[0][1..]);
 
                 let canonical_path = match path.canonicalize() {
-                    Ok(p) if p.starts_with(&dir) => p,
+                    Ok(p) if p.starts_with(dir) => p,
                     Ok(_) => {
                         log::warn!("processing HTTP req {}: 403 path outside cache dir", req.url());
                         return Ok(Response::empty(403).boxed());


### PR DESCRIPTION
Two trivial one-character clippy fixes that have been red on `master` for a while. Surfaced by a downstream fork after enabling `cargo clippy -- -D warnings` in CI.

## Changes

- `src/mainloop.rs:336` — `clippy::to_string_in_format_args`: drop `.to_string()` inside `log::info!`. `format!` / logging macros already call `Display`; the explicit conversion is redundant and allocates.
- `src/server.rs:73` — `clippy::needless_borrows_for_generic_args`: `Path::starts_with` takes `AsRef<Path>`; both `&Path` and `Path` implement it. The `&dir` reference is noise.

Both lints are stable clippy. Verified green on `rustc 1.95` stable with `cargo clippy --all-targets --all-features -- -D warnings`.

No behaviour change. Build + existing tests still pass. Applied on top of current `master` (`c6fc18e`).