### PR TITLE
feat(rpm): add Fedora 44 to build matrix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '0 6 * * 1'  # Monday 06:00 UTC
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   actions: read
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: '0 6 * * 1'  # Monday 06:00 UTC
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['actions']
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -5,6 +5,9 @@ on:
     tags: ['v*']
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: write
 

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -1,0 +1,23 @@
+name: Build Arexibo DEB
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    uses: xibo-players/.github/.github/workflows/build-deb.yml@main
+    with:
+      package-name: arexibo
+      deb-script: 'deb/build-deb.sh'
+      distro-matrix: '["ubuntu:24.04", "debian:trixie"]'
+      arch-matrix: '["amd64", "arm64"]'
+      extra-build-deps: 'cargo cmake g++ libdbus-1-dev libzmq3-dev qt6-webengine-dev libudev-dev pkg-config'
+      gpg-sign: true
+      default-version: '0.3.3'
+      publish-to-repo: true
+    secrets: inherit

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   build:
-    uses: xibo-players/.github/.github/workflows/build-deb.yml@main
+    uses: xibo-players/.github/.github/workflows/build-deb.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
     with:
       package-name: arexibo
       deb-script: 'deb/build-deb.sh'

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   build:
-    uses: xibo-players/.github/.github/workflows/build-deb.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
+    uses: xiboplayer/.github/.github/workflows/build-deb.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
     with:
       package-name: arexibo
       deb-script: 'deb/build-deb.sh'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,13 @@
+name: Create GitHub Release
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+jobs:
+  release:
+    uses: xibo-players/.github/.github/workflows/create-release.yml@main
+    with:
+      package-name: arexibo
+      description: 'Minimal native Xibo digital signage player written in Rust.'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags: ['v*']
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   release:
     uses: xibo-players/.github/.github/workflows/create-release.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    uses: xibo-players/.github/.github/workflows/create-release.yml@main
+    uses: xibo-players/.github/.github/workflows/create-release.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
     with:
       package-name: arexibo
       description: 'Minimal native Xibo digital signage player written in Rust.'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    uses: xibo-players/.github/.github/workflows/create-release.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
+    uses: xiboplayer/.github/.github/workflows/create-release.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
     with:
       package-name: arexibo
       description: 'Minimal native Xibo digital signage player written in Rust.'

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -5,6 +5,9 @@ on:
     tags: ['v*']
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: write
 

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -1,0 +1,23 @@
+name: Build Arexibo RPM
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    uses: xibo-players/.github/.github/workflows/build-rpm.yml@main
+    with:
+      package-name: arexibo
+      rpm-spec: 'rpm/arexibo.spec'
+      fedora-matrix: '["43"]'
+      arch-matrix: '["x86_64", "aarch64"]'
+      source-tarball: 'full'
+      gpg-sign: true
+      default-version: '0.3.3'
+      publish-to-repo: true
+    secrets: inherit

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   build:
-    uses: xibo-players/.github/.github/workflows/build-rpm.yml@main
+    uses: xibo-players/.github/.github/workflows/build-rpm.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
     with:
       package-name: arexibo
       rpm-spec: 'rpm/arexibo.spec'

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -17,7 +17,7 @@ jobs:
     with:
       package-name: arexibo
       rpm-spec: 'rpm/arexibo.spec'
-      fedora-matrix: '["43"]'
+      fedora-matrix: '["43", "44"]'
       arch-matrix: '["x86_64", "aarch64"]'
       source-tarball: 'full'
       gpg-sign: true

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   build:
-    uses: xibo-players/.github/.github/workflows/build-rpm.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
+    uses: xiboplayer/.github/.github/workflows/build-rpm.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
     with:
       package-name: arexibo
       rpm-spec: 'rpm/arexibo.spec'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+name: Test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: cargo test + clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            cmake \
+            g++ \
+            libdbus-1-dev \
+            libzmq3-dev \
+            qt6-webengine-dev \
+            libudev-dev \
+            pkg-config
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache cargo build artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: cargo build
+        run: cargo build --all-features
+
+      - name: cargo test
+        run: cargo test --all-features
+
+      - name: cargo clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,14 @@ jobs:
         with:
           components: clippy
 
+      - name: Force rustup stable on PATH (ubuntu-latest ships old system cargo)
+        # Without this, `cargo build` invokes /usr/bin/cargo (1.75) which
+        # doesn't support edition2024 and breaks on modern crates.
+        run: |
+          rustup default stable
+          rustup show
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
       - name: Cache cargo build artifacts
         uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches: [master]
   pull_request:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,11 +155,11 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -276,6 +276,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,6 +373,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "dbus"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,7 +398,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -404,9 +419,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
  "block-buffer",
- "const-oid",
- "crypto-common",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -529,6 +554,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "indexmap"
@@ -667,12 +701,12 @@ dependencies = [
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -1020,8 +1054,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -1167,7 +1201,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,9 +532,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "indexmap"
-version = "2.11.4"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ dbus = "0.9"
 
 # crypto
 arc4 = "0.1"
-md-5 = "0.10"
+md-5 = "0.11"
 rsa = "0.9"
 
 # file formats

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ subprocess = "<=0.2.9"
 base64ct = "~1.6"
 rayon = "~1.10"
 rayon-core = "~1.12"
-indexmap = "~2.11"
+indexmap = "~2.13"
 
 [build-dependencies]
 cmake = "0.1"

--- a/FORK-STATUS.md
+++ b/FORK-STATUS.md
@@ -1,0 +1,95 @@
+# Fork status — `xibo-players/arexibo`
+
+This is a fork of [`birkenfeld/arexibo`](https://github.com/birkenfeld/arexibo),
+the original Rust/Qt6 Xibo signage player for Linux (primarily Raspberry Pi).
+Our fork adds release-channel infrastructure and a CI gate we want on every
+change. Some of our patches are good upstream candidates; others are
+fork-local by design.
+
+## Divergence from upstream, as of 2026-04-21
+
+Run `git log --oneline upstream/master..origin/master` to see the live list.
+
+### Category A — already PR'd upstream (awaiting maintainer review)
+
+| Our commit (squashed) | Title | Upstream PR |
+|---|---|---|
+| `c8b098a` | `fix: 2 pre-existing clippy errors` | [birkenfeld/arexibo#30](https://github.com/birkenfeld/arexibo/pull/30) |
+
+### Category B — upstream-PR candidates, queued behind #30
+
+These are genuine behaviour bug fixes that upstream would likely benefit
+from. Holding them until we see how birkenfeld reviews #30 — to avoid
+flooding the maintainer with parallel PRs before establishing a signal
+on their merge appetite.
+
+| Our commit | Fix | Why upstream-valuable |
+|---|---|---|
+| `be21c38` | `HashingWriter::write` hashes only bytes actually written | Silent MD5 corruption on every short-write path — broke resource integrity for any user |
+| `3e19742` | XMR socket gets `set_rcvtimeo(30_000)` + `assert!` → `bail!` in `process_msg` | Player wedged forever if XMR publisher dropped silently; panic on malformed frame would kill the whole player |
+| `b96062a` | `CB_STOPSHELL` reads `kill_mode` from `arg1` not `arg2` | Every CMS-triggered StopShell was a silent no-op since the feature landed (C++ side passes it as `arg1`; Rust side was reading `arg2` which is always 0) |
+| `5211aa5` | `collect_once` plumbs real `last_command_success` | `lastCommandSuccess: false` was hardcoded so the CMS thought every player command failed regardless of outcome |
+
+Trigger to open the bundle PR: either (a) birkenfeld merges PR #30, signalling they're receptive, or (b) ≥2 weeks with no response, after which we chase with a friendly follow-up.
+
+### Category C — fork-local by design (do NOT upstream)
+
+Our release channel + packaging machinery, tied to `dl.xiboplayer.org`
+and the `xibo-players` GitHub org's release workflow. Upstream has no
+use for these.
+
+| Commit(s) | What |
+|---|---|
+| `0d773d2` | feat: add RPM and DEB packaging |
+| `e613383` | docs(README): SRPMs rebuild + verify section |
+| `86e9630` | docs(README): binary builds DO ship (our tag pipeline) |
+| `19caf47` | fix(rpm): correct day-of-week in `%changelog` dates |
+| `3e01206` | ci: GitHub Actions workflows + Dependabot |
+| `2a124c5` | security: CodeQL analysis workflow |
+| `09b0619` | ci(test): cargo test + clippy gate (our fork's specific config) |
+| `60f66f4` | ci: `rust-toolchain.toml` from `1.75.0` pin → `stable` — upstream keeps the MSRV pin |
+| `7f175eb` | ci: force rustup stable on PATH (no longer needed after `60f66f4` but harmless) |
+
+### Category D — upstream-PR candidates with unclear value
+
+Possibly useful upstream, possibly not. Defer until someone actually asks.
+
+| Commit | What |
+|---|---|
+| `8cbd33c` | fix: sort changelog in descending chronological order — upstream doesn't ship a changelog file so this is arguably fork-specific |
+| `04f8023` | security: pin GitHub Actions to SHA digests — broadly good practice, but upstream runs few GH Actions so low impact |
+| `9fc1d4a` | feat: add `arexibo.service` systemd user unit — nice to have for distro packagers; defer until a packager asks |
+
+### Category E — fork-specific audit markers
+
+| Commit | What |
+|---|---|
+| `abcf1f6` | scaffold(audit): mark 3 arexibo bugs as TODOs — from overnight-audit-2026-04-21 |
+
+### Category F — automatic
+
+Dependabot bumps (`f7ec095`, `30b6756`, etc.) — replay as they appear upstream too.
+
+## Rules for future contributors
+
+1. **Before adding a new commit on `master`**, decide its category.
+   Record the intent in the commit body ("Fork-local: our release machinery"
+   vs "Upstream candidate: behaviour fix").
+2. **When rebasing on upstream**, drop commits that have become
+   redundant (upstream implemented the same fix differently) — do NOT
+   silently carry them as duplicates.
+3. **When opening an upstream PR**, do it from our fork directly:
+   `xibo-players/arexibo` is the GitHub-recognised fork of
+   `birkenfeld/arexibo` (`linuxnow/arexibo` redirects to us — the
+   linuxnow repo was transferred to the org during the account
+   consolidation; compare-URLs only work from the `xibo-players`
+   namespace).
+4. **Never force-push `master`** without announcing in this file's
+   history. The 2026-04-21 rebase-on-upstream was the first and
+   should be the last for a long time.
+
+## Maintainer context
+
+Primary point of contact for this fork: Pau Aliagas <pau@xiboplayer.org>.
+Discussion of upstreaming strategy: private in
+`xibo-players/xiboplayer-compliance` (tracking issue #TBD).

--- a/FORK-STATUS.md
+++ b/FORK-STATUS.md
@@ -1,4 +1,4 @@
-# Fork status — `xibo-players/arexibo`
+# Fork status — `xiboplayer/arexibo`
 
 This is a fork of [`birkenfeld/arexibo`](https://github.com/birkenfeld/arexibo),
 the original Rust/Qt6 Xibo signage player for Linux (primarily Raspberry Pi).
@@ -79,7 +79,7 @@ Dependabot bumps (`f7ec095`, `30b6756`, etc.) — replay as they appear upstream
    redundant (upstream implemented the same fix differently) — do NOT
    silently carry them as duplicates.
 3. **When opening an upstream PR**, do it from our fork directly:
-   `xibo-players/arexibo` is the GitHub-recognised fork of
+   `xiboplayer/arexibo` is the GitHub-recognised fork of
    `birkenfeld/arexibo` (`linuxnow/arexibo` redirects to us — the
    linuxnow repo was transferred to the org during the account
    consolidation; compare-URLs only work from the `xibo-players`
@@ -92,4 +92,4 @@ Dependabot bumps (`f7ec095`, `30b6756`, etc.) — replay as they appear upstream
 
 Primary point of contact for this fork: Pau Aliagas <pau@xiboplayer.org>.
 Discussion of upstreaming strategy: private in
-`xibo-players/xiboplayer-compliance` (tracking issue #TBD).
+`xiboplayer/xiboplayer-compliance` (tracking issue #TBD).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,15 @@ unless tested.
 
 ## Installation
 
-Currently, no binary builds are provided.
+Binary builds are published on every tagged release:
+
+* **RPM** (Fedora/RHEL) and **DEB** (Debian/Ubuntu) packages, produced by
+  the `rpm.yml` and `deb.yml` GitHub Actions workflows on tag pushes.
+* **SRPMs** are published alongside the GitHub Releases assets so you can
+  rebuild from source without running the full Cargo toolchain directly.
+
+Install from the xiboplayer package repos listed at
+<https://xibo-players.github.io/>.
 
 To build from source, you need:
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,125 @@ zeromq-devel qt6-qtwebengine-devel`.  For Debian derived, install `cmake g++
 cargo libdbus-1-dev libzmq3-dev qt6-webengine-dev`.
 
 
+## SRPMs (source RPMs)
+
+The `rpm/arexibo.spec` file drives RPM packaging for Fedora and RHEL-derived
+distributions. Two ways to use it:
+
+### Option A — rebuild from a published SRPM
+
+When a release ships, the CI workflow runs `rpmbuild -ba` on
+`rpm/arexibo.spec`, which produces both a binary RPM and a **source RPM
+(SRPM)**. Both are published to the xiboplayer R2 bucket under
+`dl.xiboplayer.org`. The layout mirrors the rpmbuild directory convention:
+
+```
+# Binary RPM
+https://dl.xiboplayer.org/rpm/fedora/<fedora_version>/<arch>/arexibo-<version>-<release>.fc<fedora_version>.<arch>.rpm
+
+# SRPM (note the uppercase SRPMS/ directory)
+https://dl.xiboplayer.org/rpm/fedora/<fedora_version>/SRPMS/arexibo-<version>-<release>.fc<fedora_version>.src.rpm
+```
+
+For example, the current Fedora 43 x86_64 binary and matching SRPM:
+
+```bash
+# Binary install
+curl -O https://dl.xiboplayer.org/rpm/fedora/43/x86_64/arexibo-0.3.3-3.fc43.x86_64.rpm
+sudo dnf install ./arexibo-0.3.3-3.fc43.x86_64.rpm
+
+# SRPM download
+curl -O https://dl.xiboplayer.org/rpm/fedora/43/SRPMS/arexibo-0.3.3-3.fc43.src.rpm
+```
+
+Old releases remain in the bucket — the SRPMS/ directory is append-only, so
+any historical release you want to rebuild or audit is reachable at its
+original URL.
+
+With the SRPM in hand, rebuild a binary RPM for your distribution and
+architecture with either `rpmbuild --rebuild` (native toolchain) or `mock`
+(clean chroot — recommended for reproducible builds):
+
+```bash
+# Native rebuild
+rpmbuild --rebuild arexibo-0.3.3-3.fc43.src.rpm
+
+# Clean-chroot rebuild via mock (reproducible; requires mock installed)
+mock -r fedora-43-x86_64 arexibo-0.3.3-3.fc43.src.rpm
+
+# Rebuild for a different Fedora release
+mock -r fedora-44-x86_64 arexibo-0.3.3-3.fc43.src.rpm
+
+# Rebuild for aarch64 (if your host supports it)
+mock -r fedora-43-aarch64 arexibo-0.3.3-3.fc43.src.rpm
+```
+
+The resulting binary RPM lands in `~/rpmbuild/RPMS/<arch>/` (native) or
+`/var/lib/mock/<target>/result/` (mock).
+
+### Option B — build an SRPM locally from a git checkout
+
+For verifying the spec file, testing packaging changes, or producing an SRPM
+for a version that hasn't been released yet:
+
+```bash
+# 1. Clone the repo and check out the version you want
+git clone https://github.com/xibo-players/arexibo.git
+cd arexibo
+git checkout v0.3.3           # or any tag / commit
+
+# 2. Create the rpmbuild directory tree
+mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+
+# 3. Copy the spec file into position
+cp rpm/arexibo.spec ~/rpmbuild/SPECS/
+
+# 4. Create the source tarball with the expected layout
+#    (rpmbuild -bs expects ${name}-${version}/ inside the tarball)
+VERSION=$(awk '/^Version:/ {print $2}' rpm/arexibo.spec)
+git archive --prefix=arexibo-${VERSION}/ HEAD \
+  | gzip > ~/rpmbuild/SOURCES/arexibo-${VERSION}.tar.gz
+
+# 5. Build the SRPM (just the source RPM — no compile step)
+rpmbuild -bs ~/rpmbuild/SPECS/arexibo.spec
+
+# 6. The SRPM lands at:
+ls ~/rpmbuild/SRPMS/arexibo-${VERSION}-*.src.rpm
+```
+
+Useful for auditing the packaging, testing a spec change before pushing, or
+producing an SRPM for a development branch.
+
+### Verifying SRPM signatures
+
+SRPMs published to `dl.xiboplayer.org` are GPG-signed with the xiboplayer
+signing key. To verify a downloaded SRPM:
+
+```bash
+# Import the xiboplayer signing key (one-time)
+sudo rpm --import https://dl.xiboplayer.org/rpm/RPM-GPG-KEY
+
+# Verify the SRPM signature
+rpm --checksig arexibo-0.3.3-3.fc43.src.rpm
+# Expected output: arexibo-0.3.3-3.fc43.src.rpm: digests signatures OK
+```
+
+### Why SRPMs are worth keeping
+
+- **Reproducible rebuilds** for distros or architectures that aren't in the
+  CI matrix (e.g. RHEL 10, OpenSUSE, ppc64le).
+- **Packaging audits** — the SRPM bundles the exact source tarball, spec
+  file, and patches used to produce the binary RPM, so a downstream
+  packager or security auditor can verify the build inputs without
+  trusting the binary.
+- **Copr / OBS forks** — the SRPM is the canonical input format for Fedora
+  Copr and OpenSUSE Build Service, so a community member running their own
+  build pipeline can do it with one file.
+- **Air-gapped deployments** — SRPMs are self-contained, so a signage
+  deployment without internet access can ship with an SRPM and rebuild
+  on-site against the exact same source and spec the upstream release used.
+
+
 ## Usage
 
 Create a new directory where Arexibo can store configuration and media files.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Binary builds are published on every tagged release:
   rebuild from source without running the full Cargo toolchain directly.
 
 Install from the xiboplayer package repos listed at
-<https://xibo-players.github.io/>.
+<https://xiboplayer.github.io/>.
 
 To build from source, you need:
 
@@ -126,7 +126,7 @@ for a version that hasn't been released yet:
 
 ```bash
 # 1. Clone the repo and check out the version you want
-git clone https://github.com/xibo-players/arexibo.git
+git clone https://github.com/xiboplayer/arexibo.git
 cd arexibo
 git checkout v0.3.3           # or any tag / commit
 

--- a/arexibo.service
+++ b/arexibo.service
@@ -1,0 +1,29 @@
+# arexibo - Rust-based digital signage player for Xibo CMS
+# systemd user unit
+
+[Unit]
+Description=arexibo Digital Signage Player
+After=graphical-session.target
+Requisite=graphical-session.target
+StartLimitBurst=20
+StartLimitIntervalSec=300
+
+[Service]
+Type=simple
+EnvironmentFile=-%h/.local/share/xibo/env
+ExecStart=/usr/bin/arexibo --allow-offline %h/.local/share/xibo
+ExecStartPre=/bin/sh -c '[ -f %h/.local/share/xibo/cms.json ]'
+Restart=on-failure
+RestartSec=5s
+
+# Resource limits
+MemoryMax=1536M
+MemoryHigh=1G
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=arexibo
+
+[Install]
+WantedBy=graphical-session.target

--- a/deb/build-deb.sh
+++ b/deb/build-deb.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Build arexibo DEB package
+# Usage: ./deb/build-deb.sh <version> [release]
+set -euo pipefail
+
+VERSION="${1:?Usage: $0 <version> [release]}"
+
+# Parse version-release (e.g. 0.3.1-2 → version=0.3.1, release=2)
+# $2 from shared workflow overrides parsed release
+BASE_VERSION="${VERSION%%-*}"
+if [[ -n "${2:-}" ]]; then
+  RELEASE="$2"
+elif [[ "$VERSION" == *-* ]]; then
+  RELEASE="${VERSION#*-}"
+else
+  RELEASE="1"
+fi
+
+# Detect architecture
+ARCH=$(dpkg --print-architecture)
+
+echo "Building arexibo ${BASE_VERSION}-${RELEASE} for ${ARCH}"
+
+# Build Rust binary
+export CARGO_NET_GIT_FETCH_WITH_CLI=true
+cargo build --release
+
+# Create DEB package structure
+PKG_DIR="deb-pkg/arexibo"
+rm -rf deb-pkg
+mkdir -p "${PKG_DIR}/DEBIAN"
+mkdir -p "${PKG_DIR}/usr/bin"
+mkdir -p "${PKG_DIR}/usr/share/doc/arexibo"
+mkdir -p "${PKG_DIR}/usr/share/applications"
+mkdir -p "${PKG_DIR}/usr/share/icons/hicolor/256x256/apps"
+mkdir -p "${PKG_DIR}/usr/share/icons/hicolor/scalable/apps"
+mkdir -p "${PKG_DIR}/usr/lib/systemd/user"
+
+# Install files
+install -m755 target/release/arexibo "${PKG_DIR}/usr/bin/arexibo"
+install -m644 arexibo.service "${PKG_DIR}/usr/lib/systemd/user/arexibo.service"
+install -m644 LICENSE "${PKG_DIR}/usr/share/doc/arexibo/"
+install -m644 README.md "${PKG_DIR}/usr/share/doc/arexibo/"
+install -m644 CHANGELOG.md "${PKG_DIR}/usr/share/doc/arexibo/"
+install -m644 arexibo.desktop "${PKG_DIR}/usr/share/applications/"
+install -m644 assets/arexibo-256.png "${PKG_DIR}/usr/share/icons/hicolor/256x256/apps/arexibo.png"
+install -m644 assets/logo.svg "${PKG_DIR}/usr/share/icons/hicolor/scalable/apps/arexibo.svg"
+
+# Create control file
+cat > "${PKG_DIR}/DEBIAN/control" << EOF
+Package: arexibo
+Version: ${BASE_VERSION}-${RELEASE}
+Section: misc
+Priority: optional
+Architecture: ${ARCH}
+Depends: libqt6webenginecore6, libqt6webenginewidgets6, libdbus-1-3, libzmq5
+Maintainer: Pau Aliagas <pau@linuxnow.com>
+Description: Rust-based digital signage player for Xibo CMS
+ Arexibo is a Rust-based digital signage player compatible with Xibo CMS.
+ It provides a lightweight alternative to the official Xibo player,
+ designed for kiosk and digital signage deployments on Linux.
+Homepage: https://github.com/birkenfeld/arexibo
+EOF
+
+# Build DEB
+mkdir -p dist
+dpkg-deb --build "${PKG_DIR}" "dist/arexibo_${BASE_VERSION}-${RELEASE}_${ARCH}.deb"
+
+echo "Built DEBs:"
+ls -lh dist/*.deb
+
+# Clean up
+rm -rf deb-pkg

--- a/rpm/arexibo.spec
+++ b/rpm/arexibo.spec
@@ -54,18 +54,17 @@ install -Dm644 arexibo.service %{buildroot}%{_userunitdir}/arexibo.service
 - Add arexibo.service systemd user unit
 - Add unit tests for config and util modules
 
-* Wed Mar 12 2026 Pau Aliagas <pau@linuxnow.com> - 0.3.1-4
-- Install desktop entry and icon in RPM and DEB packages
-- Merge upstream dependency updates
-
 * Sat Mar 29 2026 Pau Aliagas <linuxnow@gmail.com> - 0.3.3-2
 - Rebuild for Fedora 44
 
 * Sun Mar 23 2026 Pau Aliagas <linuxnow@gmail.com> - 0.3.3-1
 - Sync with upstream v0.3.3
 
-* Fri Feb 28 2026 Pau Aliagas <pau@linuxnow.com> - 0.3.1-2
-- Install desktop entry and icon for proper desktop integration (closes #6)
+* Wed Mar 12 2026 Pau Aliagas <linuxnow@gmail.com> - 0.3.1-4
+- Install desktop entry and icon in RPM and DEB packages
+
+* Fri Feb 28 2026 Pau Aliagas <linuxnow@gmail.com> - 0.3.1-2
+- Install desktop entry and icon for proper desktop integration
 
 * Tue Feb 18 2026 Pau Aliagas <pau@linuxnow.com> - 0.3.1-1
 - Clean rebuild: PDF support, NotAuthorized exit code, dependency updates

--- a/rpm/arexibo.spec
+++ b/rpm/arexibo.spec
@@ -1,0 +1,72 @@
+%global debug_package %{nil}
+
+Name:           arexibo
+Version:        0.3.3
+Release:        3%{?dist}
+Summary:        Rust-based digital signage player for Xibo CMS
+
+License:        AGPLv3+
+URL:            https://github.com/xibo-players/arexibo
+Source0:        %{name}-%{version}.tar.gz
+
+BuildRequires:  rust >= 1.75
+BuildRequires:  cargo
+BuildRequires:  cmake
+BuildRequires:  gcc-c++
+BuildRequires:  dbus-devel >= 1.6
+BuildRequires:  zeromq-devel >= 4.1
+BuildRequires:  qt6-qtwebengine-devel
+
+Requires:       qt6-qtwebengine
+Requires:       dbus
+Requires:       zeromq
+
+%description
+Arexibo is a Rust-based digital signage player compatible with Xibo CMS.
+It provides a lightweight alternative to the official Xibo player,
+designed for kiosk and digital signage deployments on Linux.
+
+%prep
+%autosetup -n %{name}-%{version}
+
+%build
+export CARGO_NET_GIT_FETCH_WITH_CLI=true
+cargo build --release
+
+%install
+install -Dm755 target/release/arexibo %{buildroot}%{_bindir}/arexibo
+install -Dm644 arexibo.desktop %{buildroot}%{_datadir}/applications/arexibo.desktop
+install -Dm644 assets/arexibo-256.png %{buildroot}%{_datadir}/icons/hicolor/256x256/apps/arexibo.png
+install -Dm644 assets/logo.svg %{buildroot}%{_datadir}/icons/hicolor/scalable/apps/arexibo.svg
+install -Dm644 arexibo.service %{buildroot}%{_userunitdir}/arexibo.service
+
+%files
+%license LICENSE
+%doc README.md CHANGELOG.md
+%{_bindir}/arexibo
+%{_userunitdir}/arexibo.service
+%{_datadir}/applications/arexibo.desktop
+%{_datadir}/icons/hicolor/256x256/apps/arexibo.png
+%{_datadir}/icons/hicolor/scalable/apps/arexibo.svg
+
+%changelog
+* Wed Apr 02 2026 Pau Aliagas <linuxnow@gmail.com> - 0.3.3-3
+- Add arexibo.service systemd user unit
+- Add unit tests for config and util modules
+
+* Wed Mar 12 2026 Pau Aliagas <pau@linuxnow.com> - 0.3.1-4
+- Install desktop entry and icon in RPM and DEB packages
+- Merge upstream dependency updates
+
+* Sat Mar 29 2026 Pau Aliagas <linuxnow@gmail.com> - 0.3.3-2
+- Rebuild for Fedora 44
+
+* Sun Mar 23 2026 Pau Aliagas <linuxnow@gmail.com> - 0.3.3-1
+- Sync with upstream v0.3.3
+
+* Fri Feb 28 2026 Pau Aliagas <pau@linuxnow.com> - 0.3.1-2
+- Install desktop entry and icon for proper desktop integration (closes #6)
+
+* Tue Feb 18 2026 Pau Aliagas <pau@linuxnow.com> - 0.3.1-1
+- Clean rebuild: PDF support, NotAuthorized exit code, dependency updates
+- Thin workflow callers for RPM, DEB and image builds

--- a/rpm/arexibo.spec
+++ b/rpm/arexibo.spec
@@ -50,22 +50,22 @@ install -Dm644 arexibo.service %{buildroot}%{_userunitdir}/arexibo.service
 %{_datadir}/icons/hicolor/scalable/apps/arexibo.svg
 
 %changelog
-* Wed Apr 02 2026 Pau Aliagas <linuxnow@gmail.com> - 0.3.3-3
+* Thu Apr 02 2026 Pau Aliagas <linuxnow@gmail.com> - 0.3.3-3
 - Add arexibo.service systemd user unit
 - Add unit tests for config and util modules
 
-* Sat Mar 29 2026 Pau Aliagas <linuxnow@gmail.com> - 0.3.3-2
+* Sun Mar 29 2026 Pau Aliagas <linuxnow@gmail.com> - 0.3.3-2
 - Rebuild for Fedora 44
 
-* Sun Mar 23 2026 Pau Aliagas <linuxnow@gmail.com> - 0.3.3-1
+* Mon Mar 23 2026 Pau Aliagas <linuxnow@gmail.com> - 0.3.3-1
 - Sync with upstream v0.3.3
 
-* Wed Mar 12 2026 Pau Aliagas <linuxnow@gmail.com> - 0.3.1-4
+* Thu Mar 12 2026 Pau Aliagas <linuxnow@gmail.com> - 0.3.1-4
 - Install desktop entry and icon in RPM and DEB packages
 
-* Fri Feb 28 2026 Pau Aliagas <linuxnow@gmail.com> - 0.3.1-2
+* Sat Feb 28 2026 Pau Aliagas <linuxnow@gmail.com> - 0.3.1-2
 - Install desktop entry and icon for proper desktop integration
 
-* Tue Feb 18 2026 Pau Aliagas <pau@linuxnow.com> - 0.3.1-1
+* Wed Feb 18 2026 Pau Aliagas <pau@linuxnow.com> - 0.3.1-1
 - Clean rebuild: PDF support, NotAuthorized exit code, dependency updates
 - Thin workflow callers for RPM, DEB and image builds

--- a/rpm/arexibo.spec
+++ b/rpm/arexibo.spec
@@ -6,7 +6,7 @@ Release:        3%{?dist}
 Summary:        Rust-based digital signage player for Xibo CMS
 
 License:        AGPLv3+
-URL:            https://github.com/xibo-players/arexibo
+URL:            https://github.com/xiboplayer/arexibo
 Source0:        %{name}-%{version}.tar.gz
 
 BuildRequires:  rust >= 1.75

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,7 @@
 [toolchain]
-channel = "1.75.0"
+# Upstream pins 1.75.0 (Nov 2023) but transitive deps now require
+# edition2024, which only stabilised in Cargo 1.85 (Feb 2025).
+# Our fork uses "stable" so CI + local builds track whatever Rust
+# is current. Revisit only if we pick up a nightly-only feature or
+# need MSRV guarantees for a downstream consumer.
+channel = "stable"

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -132,7 +132,13 @@ extern "C" fn callback(ptr: *mut c_void, typ: isize, arg1: isize, arg2: isize, _
             }
         }
         cpp::CB_STOPSHELL => {
-            let killmode = match arg2 & 0xff {
+            // Fixes #30: read arg1, not arg2. gui/view.cpp:184 passes
+            // kill_mode as the third cb() parameter →
+            //   cb(ptr, CB_STOPSHELL, kill_mode, 0, 0)
+            // which arrives here as arg1. arg2 is always 0, so every
+            // stop was collapsing to Kill::No and shells never
+            // terminated.
+            let killmode = match arg1 & 0xff {
                 0 => Kill::No,
                 1 => Kill::Terminate,
                 _ => Kill::Kill,

--- a/src/mainloop.rs
+++ b/src/mainloop.rs
@@ -333,7 +333,7 @@ impl Handler {
     fn schedule_check(&mut self) {
         let new_layouts = self.schedule.layouts_now();
         if new_layouts != self.layouts {
-            log::info!("new layouts in schedule: {}", new_layouts.iter().format(", ").to_string());
+            log::info!("new layouts in schedule: {}", new_layouts.iter().format(", "));
             self.to_gui.send(ToGui::Layouts(new_layouts.clone())).unwrap();
             self.layouts = new_layouts;
         }

--- a/src/mainloop.rs
+++ b/src/mainloop.rs
@@ -65,6 +65,10 @@ pub struct Handler {
     layouts: Vec<i64>,
     current_layout: i64,
     shell_process: Option<Popen>,
+    /// Outcome of the most recently run player command (None if no
+    /// command has run yet in this lifetime). Included in every
+    /// collection-cycle status report. Fixes #25.
+    last_command_success: Option<bool>,
 }
 
 impl Handler {
@@ -124,7 +128,7 @@ impl Handler {
 
             let mut slf = Self { to_gui, from_gui, settings, cache, xmds, xmr, schedule,
                                  layouts, envdir: envdir.into(), current_layout: 0,
-                                 shell_process: None };
+                                 shell_process: None, last_command_success: None };
             slf.update_settings();
             slf.schedule_check();  // only useful in case of cached schedule
             Ok(slf)
@@ -224,6 +228,7 @@ impl Handler {
                     false
                 }
             };
+            self.last_command_success = Some(success);
             let _ = self.xmds.notify_command_success(success);
         } else {
             log::error!("no such player command: {code}");
@@ -310,7 +315,11 @@ impl Handler {
             currentLayoutId: self.current_layout,
             availableSpace: avail,
             totalSpace: total,
-            lastCommandSuccess: false,  // not implemented yet
+            // If no command has run yet this lifetime, report success=true
+            // (no failure to report). Matches Xibo's public-player
+            // convention: absence of a failure is not itself a failure.
+            // Fixes #25.
+            lastCommandSuccess: self.last_command_success.unwrap_or(true),
             deviceName: &self.settings.display_name,
             timeZone: &util::timezone(),
         };

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -358,15 +358,12 @@ impl<W> HashingWriter<W> {
 impl<W> Write for HashingWriter<W> where W: Write {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let len = self.writer.write(buf)?;
-        // TODO(scaffold #28, audit 2026-04-21): hash only &buf[..len], not
-        // the full input buffer. Short writes (len < buf.len()) contaminate
-        // the running MD5 with trailing unwritten bytes, producing silent
-        // corruption — the file integrity check rejects any resource
-        // download that happened to short-write.
-        // Fix: self.hasher.update(&buf[..len]);
-        // Out-of-scope tonight: change-of-behaviour, needs its own PR with
-        // a regression test.
-        self.hasher.update(buf);
+        // Hash only the bytes ACTUALLY written. A short write
+        // (len < buf.len()) would otherwise contaminate the running MD5
+        // with trailing unwritten bytes, silently corrupting the resource
+        // integrity check and rejecting every download that happened to
+        // short-write. Fixes #28.
+        self.hasher.update(&buf[..len]);
         Ok(len)
     }
 

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -358,6 +358,14 @@ impl<W> HashingWriter<W> {
 impl<W> Write for HashingWriter<W> where W: Write {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let len = self.writer.write(buf)?;
+        // TODO(scaffold #28, audit 2026-04-21): hash only &buf[..len], not
+        // the full input buffer. Short writes (len < buf.len()) contaminate
+        // the running MD5 with trailing unwritten bytes, producing silent
+        // corruption — the file integrity check rejects any resource
+        // download that happened to short-write.
+        // Fix: self.hasher.update(&buf[..len]);
+        // Out-of-scope tonight: change-of-behaviour, needs its own PR with
+        // a regression test.
         self.hasher.update(buf);
         Ok(len)
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -70,7 +70,7 @@ impl Server {
                 let path = dir.join(&parts[0][1..]);
 
                 let canonical_path = match path.canonicalize() {
-                    Ok(p) if p.starts_with(&dir) => p,
+                    Ok(p) if p.starts_with(dir) => p,
                     Ok(_) => {
                         log::warn!("processing HTTP req {}: 403 path outside cache dir", req.url());
                         return Ok(Response::empty(403).boxed());

--- a/src/xmr.rs
+++ b/src/xmr.rs
@@ -3,7 +3,7 @@
 
 //! Receive, decrypt and handle incoming XMR messages from CMS.
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use crossbeam_channel::{Receiver, Sender, unbounded};
 use rsa::RsaPrivateKey;
@@ -40,14 +40,12 @@ impl Manager {
         let socket = context.socket(zmq::SUB).context("creating XMR socket")?;
         socket.connect(connect).context("connecting XMR socket")?;
         socket.set_linger(0)?;
-        // TODO(scaffold #31, audit 2026-04-21): without a recv timeout,
-        // recv_msg blocks forever if the XMR publisher goes away silently
-        // (CMS restart, network drop). Player wedges on the next heartbeat
-        // window and never reconnects.
-        // Fix: socket.set_rcvtimeo(30_000)?;
-        // 30s matches the CMS heartbeat cadence. Out-of-scope tonight:
-        // change-of-behaviour, needs its own PR with a regression test
-        // that exercises the reconnect path after a publisher drop.
+        // 30s receive timeout matches the CMS heartbeat cadence.
+        // Without a timeout, recv_msg blocks forever if the publisher
+        // goes away silently (CMS restart, network drop), and the
+        // player wedges on the next heartbeat window and never
+        // reconnects. Fixes #31.
+        socket.set_rcvtimeo(30_000)?;
         socket.set_subscribe(channel.as_bytes())?;
         socket.set_subscribe(HEARTBEAT)?;
         let (sender, receiver) = unbounded();
@@ -69,12 +67,22 @@ impl Manager {
     }
 
     fn process_msg(&mut self) -> Result<()> {
+        // Fixes #26: don't panic on a malformed XMR frame. A malicious or
+        // truncated publisher could otherwise take the whole player down
+        // with a single bad message. bail! lets the run-loop log the
+        // error and stay alive for the next recv.
         let channel = self.socket.recv_msg(0)?;
-        assert!(channel.get_more());
+        if !channel.get_more() {
+            bail!("malformed XMR frame: expected multi-part, channel is terminal");
+        }
         let key = self.socket.recv_msg(0)?;
-        assert!(key.get_more());
+        if !key.get_more() {
+            bail!("malformed XMR frame: expected multi-part, key is terminal");
+        }
         let content = self.socket.recv_msg(0)?;
-        assert!(!content.get_more());
+        if content.get_more() {
+            bail!("malformed XMR frame: expected 3 parts, content has more");
+        }
         if &*channel != HEARTBEAT {
             let json_msg = JsonMessage::new(&self.private_key, &key, &content)?;
             log::debug!("got XMR message: {:?}", json_msg);

--- a/src/xmr.rs
+++ b/src/xmr.rs
@@ -40,6 +40,14 @@ impl Manager {
         let socket = context.socket(zmq::SUB).context("creating XMR socket")?;
         socket.connect(connect).context("connecting XMR socket")?;
         socket.set_linger(0)?;
+        // TODO(scaffold #31, audit 2026-04-21): without a recv timeout,
+        // recv_msg blocks forever if the XMR publisher goes away silently
+        // (CMS restart, network drop). Player wedges on the next heartbeat
+        // window and never reconnects.
+        // Fix: socket.set_rcvtimeo(30_000)?;
+        // 30s matches the CMS heartbeat cadence. Out-of-scope tonight:
+        // change-of-behaviour, needs its own PR with a regression test
+        // that exercises the reconnect path after a publisher drop.
         socket.set_subscribe(channel.as_bytes())?;
         socket.set_subscribe(HEARTBEAT)?;
         let (sender, receiver) = unbounded();


### PR DESCRIPTION
Closes #63.

## Summary

One-line change extending `arexibo/.github/workflows/rpm.yml`'s `fedora-matrix` from `["43"]` to `["43", "44"]`.

Why arexibo first (smallest blast to validate F44 in the shared `build-rpm.yml` reusable): pure Rust, no Node deps, no Chromium pin. Once this lands green, the same one-line change can roll out to xiboplayer-kiosk, xiboplayer-electron, xiboplayer-chromium, xiboplayer-chrome, xiboplayer-tizen, xiboplayer-webos in follow-up PRs.

Pre-flight checks captured in #63:

- Spec uses `Release: 3%{?dist}` — `.fc44.` naming is automatic.
- F44 base packages (`rust`, `cargo`, `dbus-devel`, `zeromq-devel`, `qt6-qtwebengine-devel`) all resolvable per the overnight audit (D3).
- Shared `build-rpm.yml` already declares `FEDORA_VERS="43 44"` in its R2 upload step — no reusable-workflow change required.
- `xiboplayer-release-44-7.fc44.noarch.rpm` is already live on R2.

## Test plan

- [ ] After merge: push a patch tag (e.g. `v0.3.3-4`) to trigger the workflow.
- [ ] Confirm both `arexibo-0.3.3-N.fc43.{x86_64,aarch64}.rpm` and `arexibo-0.3.3-N.fc44.{x86_64,aarch64}.rpm` land on R2.
- [ ] Confirm `update-repos.yml` on `xiboplayer.github.io` regenerates F44 repodata so the new RPMs appear in `dl.xiboplayer.org/rpm/fedora/44/{x86_64,aarch64}/`.
- [ ] On a Fedora 44 box: `sudo dnf install https://dl.xiboplayer.org/rpm/fedora/44/noarch/xiboplayer-release-44-7.fc44.noarch.rpm && sudo dnf install arexibo` should succeed.

## Risk

Low. Build matrix change only. If F44 builds fail or the reusable workflow has a F44-specific bug, the F43 builds still proceed (parallel matrix). Worst case: F44 RPMs don't appear in the repo until the issue is fixed, but F43 users are unaffected.

## Follow-ups (out of scope)

- Roll out the same matrix bump to the remaining form-factor repos once this PR validates F44 end-to-end.
- D3 flagged a soft caveat on `nodejs`/`nodejs-libs` for F44 (they resolve via virtual provides defaulting to `nodejs22`; F44 ships `nodejs24` so the default may drift). Arexibo doesn't use Node, so unaffected — but kiosk/electron/chromium PRs should pin explicit `nodejs22`/`nodejs22-libs`/`nodejs22-npm` when they extend.