### PR TITLE
fix: navigate when update() advances the index past a completed layout

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -162,13 +162,27 @@ impl<T: Eq + Default + Clone> Schedule<T> {
 
         // if this layout is also in the new schedule, keep it
         if let Some(new_index) = self.layouts.iter().position(|t| t == &cur_t) {
-            if self.single_done {
-                self.index = Some((new_index + 1) % self.layouts.len());
+            let idx = if self.single_done {
+                (new_index + 1) % self.layouts.len()
             } else {
-                self.index = Some(new_index);
-            }
+                new_index
+            };
+            self.index = Some(idx);
             self.single_done = false;
-            None
+            // Report a change only when the *layout* differs from what is on
+            // screen.  Comparing indices is not enough: the index moves whenever
+            // the CMS reorders the list, and returning Some in that case would
+            // re-navigate to the layout already showing.
+            //
+            // Returning None here while having moved the index is what left the
+            // player permanently stuck: current() then reported the new layout,
+            // so the next update() found it already "current" and never
+            // navigated.
+            if self.layouts[idx] != cur_t {
+                Some(self.layouts[idx].clone())
+            } else {
+                None
+            }
         } else if !self.layouts.is_empty() {
             // otherwise, start showing the first of the new layouts if we have some
             self.index = Some(0);
@@ -231,4 +245,28 @@ fn test_schedule() {
     assert_eq!(schedule.next(), Some(3));
     assert_eq!(schedule.next(), Some(2));
     assert_eq!(schedule.update(vec![1, 3]), Some(1));
+}
+
+#[cfg(test)]
+#[test]
+fn test_schedule_single_done_navigates() {
+    // A single scheduled layout that has played through once must not leave the
+    // schedule desynchronised from the view when the schedule then changes.
+    let mut schedule = Schedule { index: None, layouts: vec![], single_done: false };
+
+    // one layout scheduled and shown
+    assert_eq!(schedule.update(vec![14]), Some(14));
+
+    // it finishes; only one is scheduled, so next() declines and the caller
+    // marks it done
+    assert_eq!(schedule.next(), None);
+    schedule.mark_done();
+
+    // the schedule grows: the index advances past the layout that has run, and
+    // the caller must be told to navigate
+    assert_eq!(schedule.update(vec![14, 24]), Some(24));
+    assert_eq!(schedule.current(), 24);
+
+    // and once it is showing 24, a schedule of just [24] is not a change
+    assert_eq!(schedule.update(vec![24]), None);
 }


### PR DESCRIPTION
### What happens

A display playing a **single scheduled layout** stops responding to schedule
changes once that layout has played through. Adding, removing or replacing
scheduled events has no effect, and neither does *Collect Now*. The player keeps
showing the original layout until it is restarted.

There is no error anywhere. The player logs a normal collection, the CMS reports
the display as up to date, and the schedule in the CMS is correct — so the fault
reads as a scheduling mistake rather than a player bug. It cost me most of a day
to find, which is why I thought it worth reporting properly.

### Root cause

In `Schedule::update()` (`src/gui.rs`), when the currently-shown layout is still
present in the new schedule and `single_done` is set, the index is advanced past
it — but the function returns `None`, so the caller never navigates:

```rust
if let Some(new_index) = self.layouts.iter().position(|t| t == &cur_t) {
    if self.single_done {
        self.index = Some((new_index + 1) % self.layouts.len());   // index moves
    } else {
        self.index = Some(new_index);
    }
    self.single_done = false;
    None                                                           // ...but no navigation
}
```

That leaves the schedule desynchronised from the view: `current()` now reports
the layout at the advanced index, while the screen still shows the old one. The
next `update()` therefore finds *that* layout already "current", takes the same
branch, and again returns `None`. The player can never navigate again.

It needs `single_done` to be set, which is why it only shows up once a single
scheduled layout has run through — the common case for a display with one
layout scheduled.

### Reproduction

On a Xibo 4.5.1 CMS:

1. Schedule exactly one layout to a display; let it play through at least once.
2. Schedule a second layout, or replace the first.
3. *Collect Now*.

The display keeps showing the first layout. `journalctl` shows the collection
succeeding and the new layout being downloaded.

### The fix

Report a change when the **layout** differs from what is on screen, rather than
returning unconditional `None`.

Comparing indices would not be correct: the index also moves when the CMS
reorders the list, and navigating in that case would restart the layout already
showing. So the comparison is on the layout itself, which keeps the existing
"no change" behaviour for a reorder.

### Test

Adds `test_schedule_single_done_navigates`, covering the
single-layout-played-through case.

Verified that it fails before the fix and passes after — extracting `Schedule`
and both tests and running them against each revision:

```
──── before (d47fb25) ────
test test_schedule ... ok
test test_schedule_single_done_navigates ... FAILED
  assertion `left == right` failed
    left: None
   right: Some(24)
test result: FAILED. 1 passed; 1 failed

──── after ────
test test_schedule ... ok
test test_schedule_single_done_navigates ... ok
test result: ok. 2 passed; 0 failed
```

The pre-existing `test_schedule` passes unchanged in both.

### Environment

Arexibo `d47fb25` (v0.5.1) built for aarch64 on Debian trixie, running on a
Rockchip RK3399 against a self-hosted Xibo 4.5.1 CMS. Found while commissioning
a fleet of LED-wall players.
